### PR TITLE
Experiment with an alternative file export mechanism

### DIFF
--- a/build_defs/go_module.build_defs
+++ b/build_defs/go_module.build_defs
@@ -125,3 +125,58 @@ def fileexport(name:str, srcs:list, tag:str='', deps:list=None, exported_deps:li
         binary = binary,
         hashes = hashes,
     )
+
+def fileexport2(name:str, srcs:list, tag:str='', deps:list=None, exported_deps:list=None,
+              visibility:list=None, labels:list&features&tags=None, binary:bool=False, output_is_complete:bool=True,
+              requires:list=None, provides:dict=None, hashes:list=None, test_only:bool&testonly=False):
+    """Defines a collection of files which other rules can depend on.
+    Sources can come from dependencies.
+    The exported files will appear as if they were coming from the current package.
+
+    Args:
+      name (str): Name of the rule.
+      srcs (list): Source files for the rule.
+      tag (str): Tag applied to name; generates a private rule, for example name='a',tag='b' gives
+                 _a#b. Typically used for "private" rules.
+      deps (list): Dependencies of the rule.
+      exported_deps (list): Dependencies that will become visible to any rules that depend on this rule.
+      visibility (list): Visibility declaration of the rule.
+      labels (list): Labels to apply to this rule
+      binary (bool): True to mark the rule outputs as binary
+      output_is_complete (bool): If this is true then the rule blocks downwards searches of transitive
+                                 dependencies by other rules.
+      requires (list): Kinds of output from other rules that this one requires.
+      provides (dict): Kinds of output that this provides for other rules (see genrule() for a more
+                       in-depth discussion of this).
+      hashes (list): List of acceptable output hashes for this rule.
+      test_only (bool): If true the rule will only be visible to test targets.
+    """
+
+    files = ' '.join(srcs)
+
+    outs = []
+
+    for f in srcs:
+        outs += [f"{name}/{f}"]
+
+    return build_rule(
+        name = name,
+        tag = tag,
+        cmd = '\n'.join([
+            f'files="{files}"',
+            'for f in $files; do ',
+            f'    cp -r "$SRCS/$f" {name}/$f ',
+            'done ']),
+        srcs = deps,
+        outs = outs,
+        exported_deps = exported_deps,
+        visibility = visibility,
+        building_description = 'Copying...',
+        output_is_complete = output_is_complete,
+        requires = requires,
+        provides = provides,
+        test_only = test_only,
+        labels = labels,
+        binary = binary,
+        hashes = hashes,
+    )

--- a/cmd/gogetgen/main.go
+++ b/cmd/gogetgen/main.go
@@ -190,7 +190,7 @@ func main() {
 					gofiles = append(gofiles, fmt.Sprintf("%q", path.Join(packageSource, gf)))
 				}
 
-				file += fmt.Sprintf(`fileexport(
+				file += fmt.Sprintf(`fileexport2(
     name = "%s",
     tag = "go_source",
     srcs = [%s],
@@ -210,7 +210,7 @@ func main() {
 						sfiles = append(sfiles, fmt.Sprintf("%q", path.Join(packageSource, gf)))
 					}
 
-					file += fmt.Sprintf(`fileexport(
+					file += fmt.Sprintf(`fileexport2(
     name = "%s",
     tag = "s_source",
     srcs = [%s],
@@ -232,7 +232,7 @@ func main() {
 						cgofiles = append(cgofiles, fmt.Sprintf("%q", path.Join(packageSource, gf)))
 					}
 
-					file += fmt.Sprintf(`fileexport(
+					file += fmt.Sprintf(`fileexport2(
     name = "%s",
     tag = "cgo_source",
     srcs = [%s],
@@ -248,7 +248,7 @@ func main() {
 						cfiles = append(cfiles, fmt.Sprintf("%q", path.Join(packageSource, gf)))
 					}
 
-					file += fmt.Sprintf(`fileexport(
+					file += fmt.Sprintf(`fileexport2(
     name = "%s",
     tag = "c_source",
     srcs = [%s],
@@ -264,7 +264,7 @@ func main() {
 						hfiles = append(hfiles, fmt.Sprintf("%q", path.Join(packageSource, gf)))
 					}
 
-					file += fmt.Sprintf(`fileexport(
+					file += fmt.Sprintf(`fileexport2(
     name = "%s",
     tag = "h_source",
     srcs = [%s],

--- a/example/third_party/go/emperror.dev/errors/BUILD.plz
+++ b/example/third_party/go/emperror.dev/errors/BUILD.plz
@@ -9,7 +9,7 @@ go_module_download(
     visibility = ["//example/third_party/go/emperror.dev/errors/..."],
 )
 
-fileexport(
+fileexport2(
     name = "errors",
     srcs = [
         "error_details.go",

--- a/example/third_party/go/emperror.dev/errors/match/BUILD.plz
+++ b/example/third_party/go/emperror.dev/errors/match/BUILD.plz
@@ -1,6 +1,6 @@
 subinclude("//build_defs")
 
-fileexport(
+fileexport2(
     name = "match",
     srcs = ["match/match.go"],
     tag = "go_source",

--- a/example/third_party/go/github.com/golang/snappy/BUILD.plz
+++ b/example/third_party/go/github.com/golang/snappy/BUILD.plz
@@ -9,7 +9,7 @@ go_module_download(
     visibility = ["//example/third_party/go/github.com/golang/snappy/..."],
 )
 
-fileexport(
+fileexport2(
     name = "snappy",
     srcs = [
         "decode.go",
@@ -24,7 +24,7 @@ fileexport(
     deps = [":_snappy#download"],
 )
 
-fileexport(
+fileexport2(
     name = "snappy",
     srcs = [
         "decode_amd64.s",

--- a/example/third_party/go/github.com/mattn/go-sqlite3/BUILD.plz
+++ b/example/third_party/go/github.com/mattn/go-sqlite3/BUILD.plz
@@ -9,7 +9,7 @@ go_module_download(
     visibility = ["//example/third_party/go/github.com/mattn/go-sqlite3/..."],
 )
 
-fileexport(
+fileexport2(
     name = "go-sqlite3",
     srcs = [
         "convert.go",
@@ -46,7 +46,7 @@ fileexport(
     deps = [":_go-sqlite3#download"],
 )
 
-fileexport(
+fileexport2(
     name = "go-sqlite3",
     srcs = [
         "backup.go",
@@ -63,7 +63,7 @@ fileexport(
     deps = [":_go-sqlite3#download"],
 )
 
-fileexport(
+fileexport2(
     name = "go-sqlite3",
     srcs = [
         "sqlite3-binding.c",
@@ -73,7 +73,7 @@ fileexport(
     deps = [":_go-sqlite3#download"],
 )
 
-fileexport(
+fileexport2(
     name = "go-sqlite3",
     srcs = [
         "sqlite3-binding.h",

--- a/example/third_party/go/github.com/pkg/errors/BUILD.plz
+++ b/example/third_party/go/github.com/pkg/errors/BUILD.plz
@@ -9,7 +9,7 @@ go_module_download(
     visibility = ["//example/third_party/go/github.com/pkg/errors/..."],
 )
 
-fileexport(
+fileexport2(
     name = "errors",
     srcs = [
         "cause.go",

--- a/example/third_party/go/go.uber.org/atomic/BUILD.plz
+++ b/example/third_party/go/go.uber.org/atomic/BUILD.plz
@@ -9,7 +9,7 @@ go_module_download(
     visibility = ["//example/third_party/go/go.uber.org/atomic/..."],
 )
 
-fileexport(
+fileexport2(
     name = "atomic",
     srcs = [
         "atomic.go",

--- a/example/third_party/go/go.uber.org/multierr/BUILD.plz
+++ b/example/third_party/go/go.uber.org/multierr/BUILD.plz
@@ -9,7 +9,7 @@ go_module_download(
     visibility = ["//example/third_party/go/go.uber.org/multierr/..."],
 )
 
-fileexport(
+fileexport2(
     name = "multierr",
     srcs = [
         "error.go",

--- a/example/third_party/go/golang.org/x/sys/internal/unsafeheader/BUILD.plz
+++ b/example/third_party/go/golang.org/x/sys/internal/unsafeheader/BUILD.plz
@@ -1,6 +1,6 @@
 subinclude("//build_defs")
 
-fileexport(
+fileexport2(
     name = "unsafeheader",
     srcs = ["internal/unsafeheader/unsafeheader.go"],
     tag = "go_source",

--- a/example/third_party/go/golang.org/x/sys/unix/BUILD.plz
+++ b/example/third_party/go/golang.org/x/sys/unix/BUILD.plz
@@ -1,6 +1,6 @@
 subinclude("//build_defs")
 
-fileexport(
+fileexport2(
     name = "unix",
     srcs = [
         "unix/affinity_linux.go",
@@ -269,7 +269,7 @@ fileexport(
     deps = ["//example/third_party/go/golang.org/x/sys:_sys#download"],
 )
 
-fileexport(
+fileexport2(
     name = "unix",
     srcs = [
         "unix/asm_darwin_amd64.s",


### PR DESCRIPTION
The current `fileexport` rule utilizes output_dirs which might not work well when all third party dependencies are in a single package.

This is an experiment with alternative file exporting.

Issues so far:

- The cgo rule expects go files to be in the current directory