### PR TITLE
Fix silent error on `go list`

### DIFF
--- a/pkg/golist/cmd.go
+++ b/pkg/golist/cmd.go
@@ -100,6 +100,7 @@ func List(options ListOptions) ([]Package, error) {
 	args = append(args, options.Packages...)
 
 	cmd := exec.Command("go", args...)
+	cmd.Stderr = os.Stderr
 	cmd.Env = os.Environ()
 
 	cmd.Env = append(cmd.Env, "GOOS="+options.GetOS(), "GOARCH="+options.GetArch(), "CGO_ENABLED=1")


### PR DESCRIPTION
Currently on `go list` fail I go error like:
```
panic: exit status 1

goroutine 1 [running]:
main.main()
	cmd/godeps/main.go:67 +0x16f7
```

I't really cryptic.

After this change `cmd.Output()` call don't capture `stderr` and we can see more relative `go list` error message.
For example:
```
go: github.com/joomcode/api/tools: package github.com/golang/protobuf/protoc-gen-go imported from implicitly required module; to add missing requirements, run:
	go get github.com/golang/protobuf/protoc-gen-go@v1.5.2
panic: exit status 1

goroutine 1 [running]:
main.main()
	cmd/godeps/main.go:67 +0x16f7
```