### PR TITLE
Allow non-fatal `go list` errors

### DIFF
--- a/cmd/godeps/main.go
+++ b/cmd/godeps/main.go
@@ -55,11 +55,12 @@ func main() {
 
 	for _, platform := range SupportedPlatforms {
 		options := golist.ListOptions{
-			Packages: []string{fmt.Sprintf("%s/...", rootModule)},
-			Deps:     true,
-			Test:     true,
-			OS:       platform.OS,
-			Arch:     platform.Arch,
+			Packages:       []string{fmt.Sprintf("%s/...", rootModule)},
+			Deps:           true,
+			Test:           true,
+			OS:             platform.OS,
+			Arch:           platform.Arch,
+			IgnoreNonFatal: true,
 		}
 
 		platformDeps, err := golist.List(options)

--- a/pkg/golist/cmd.go
+++ b/pkg/golist/cmd.go
@@ -58,11 +58,12 @@ func DepsWithoutTests(module string) ([]Package, error) {
 
 // ListOptions customizes a go list execution.
 type ListOptions struct {
-	Packages []string
-	Deps     bool
-	Test     bool
-	OS       string
-	Arch     string
+	Packages       []string
+	Deps           bool
+	Test           bool
+	IgnoreNonFatal bool
+	OS             string
+	Arch           string
 }
 
 // GetOS returns the OS defined in the options,
@@ -95,6 +96,10 @@ func List(options ListOptions) ([]Package, error) {
 
 	if options.Test {
 		args = append(args, "-test")
+	}
+
+	if options.IgnoreNonFatal {
+		args = append(args, "-e")
 	}
 
 	args = append(args, options.Packages...)


### PR DESCRIPTION
Ignore errors like:
```
tools/tools.go:11:2: import "golang.org/x/tools/cmd/stringer" is a program, not an importable package
```
on import like:
```
  import _ "golang.org/x/tools/cmd/stringer"
```

This imports can be used to add explicit dependency on code generator utility.